### PR TITLE
Parser monad + more parsers

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -1,9 +1,11 @@
 module Parser where
 
+import qualified Data.Char as Char
+
 type Parser a = State -> Either Error (a, State)
 
 data State = State
-  { text :: String,
+  { source :: String,
     remaining :: String,
     lastChar :: Maybe Char,
     token :: Token,
@@ -27,18 +29,16 @@ data Error = Expected String State
 infixl 1 |>
 
 parse :: String -> Parser a -> Either Error a
-parse text parser = do
-  (x, _) <-
-    parser
-      ( State
-          { text = text,
-            remaining = text,
+parse source parser = do
+  let initialState =
+        State
+          { source = source,
+            remaining = source,
             lastChar = Nothing,
             token = Token {name = "", row = 1, col = 1},
             stack = []
           }
-      )
-  Right x
+  fmap fst (parser initialState)
 
 succeed :: a -> Parser a
 succeed value state = Right (value, state)
@@ -47,16 +47,16 @@ expected :: String -> Parser a
 expected message state = Left (Expected message state)
 
 expecting :: String -> Parser a -> Parser a
-expecting message parser state =
-  case parser state of
-    Left (Expected _ state) -> Left (Expected message state)
-    x -> x
+expecting message parser state = case parser state of
+  Left (Expected _ state) -> Left (Expected message state)
+  x -> x
 
 andThen :: (a -> Parser b) -> Parser a -> Parser b
 andThen f parser state = do
-  (x, s) <- parser state
-  f x s
+  (x, state) <- parser state
+  f x state
 
+-- Single characters
 anyChar :: Parser Char
 anyChar state@State {remaining = ch : remaining, token = tok} =
   state
@@ -70,8 +70,71 @@ anyChar state@State {remaining = ch : remaining, token = tok} =
     |> succeed ch
 anyChar state = expected "a character" state
 
+charIf :: (Char -> Bool) -> String -> Parser Char
+charIf condition errorMessage =
+  andThen
+    (\ch -> if condition ch then succeed ch else expected errorMessage)
+    anyChar
+
+space :: Parser Char
+space = charIf Char.isSpace "a blank space"
+
+letter :: Parser Char
+letter = charIf Char.isLetter "a letter"
+
+letterLower :: Parser Char
+letterLower = charIf Char.isLower "a lowercase letter"
+
+letterUpper :: Parser Char
+letterUpper = charIf Char.isUpper "an uppercase letter"
+
+digit :: Parser Char
+digit = charIf Char.isDigit "a digit from 0 to 9"
+
+alphanumeric :: Parser Char
+alphanumeric = charIf Char.isAlphaNum "a letter or digit"
+
+punctuation :: Parser Char
+punctuation = charIf Char.isPunctuation "a punctuation character"
+
 char :: Char -> Parser Char
-char ch =
-  anyChar
-    |> andThen (\c -> if c == ch then succeed c else expected "")
-    |> expecting ("the character '" <> [ch] <> "'")
+char ch = charIf (\c -> Char.toLower ch == Char.toLower c) ("the character '" <> [ch] <> "'")
+
+charCaseSensitive :: Char -> Parser Char
+charCaseSensitive ch = charIf (ch ==) ("the character '" <> [ch] <> "' (case sensitive)")
+
+except :: Parser Char -> Parser Char
+except parser state =
+  case parser state of
+    Right (_, state) -> expected "something else" state
+    Left _ -> anyChar state
+
+-- Sequences
+zeroOrOne :: Parser a -> Parser [a]
+zeroOrOne parser state = case parser state of
+  Right (x, state) -> succeed [x] state
+  Left _ -> succeed [] state
+
+zeroOrMore :: Parser a -> Parser [a]
+zeroOrMore parser state = case parser state of
+  Right (x, state) -> case zeroOrMore parser state of
+    Right (xs, state) -> succeed (x : xs) state
+    Left _ -> succeed [x] state
+  Left _ -> succeed [] state
+
+oneOrMore :: Parser a -> Parser [a]
+oneOrMore parser state = do
+  (x, state) <- parser state
+  (xs, state) <- zeroOrMore parser state
+  succeed (x : xs) state
+
+chain :: [Parser a] -> Parser [a]
+chain [] state = Right ([], state)
+chain (parser : parsers) state = do
+  (x, state) <- parser state
+  (xs, state) <- chain parsers state
+  succeed (x : xs) state
+
+-- Common
+-- text
+-- textNoCase

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -6,14 +6,100 @@ import Test.Hspec
 parserTests :: SpecWith ()
 parserTests = describe "--== Parser ==--" $ do
   let error :: String -> Parser a -> Maybe String
-      error text parser = case parse text parser of
+      error source parser = case parse source parser of
         Left (Expected message _) -> Just message
         _ -> Nothing
 
-  it "☯ anyChar" $ do
-    parse "abc" anyChar `shouldBe` Right 'a'
-    error "" anyChar `shouldBe` Just "a character"
+  describe "☯ Single characters" $ do
+    it "☯ anyChar" $ do
+      parse "abc" anyChar `shouldBe` Right 'a'
+      parse "" anyChar
+        `shouldBe` Left
+          ( Expected "a character" $
+              State
+                { source = "",
+                  remaining = "",
+                  lastChar = Nothing,
+                  token = Token {name = "", row = 1, col = 1},
+                  stack = []
+                }
+          )
 
-  it "☯ char" $ do
-    parse "abc" (char 'a') `shouldBe` Right 'a'
-    error "xbc" (char 'a') `shouldBe` Just "the character 'a'"
+    it "☯ charIf" $ do
+      parse "abc" (charIf ('a' ==) "an 'a'") `shouldBe` Right 'a'
+      parse "xbc" (charIf ('a' ==) "an 'a'")
+        `shouldBe` Left
+          ( Expected "an 'a'" $
+              State
+                { source = "xbc",
+                  remaining = "bc",
+                  lastChar = Just 'x',
+                  token = Token {name = "", row = 1, col = 2},
+                  stack = []
+                }
+          )
+
+    it "☯ space" $ do
+      parse " " space `shouldBe` Right ' '
+      parse "\t" space `shouldBe` Right '\t'
+      parse "\n" space `shouldBe` Right '\n'
+      parse "\r" space `shouldBe` Right '\r'
+      parse "\f" space `shouldBe` Right '\f'
+      parse "\v" space `shouldBe` Right '\v'
+      error "a" space `shouldBe` Just "a blank space"
+
+    it "☯ letter" $ do
+      parse "a" letter `shouldBe` Right 'a'
+      parse "A" letter `shouldBe` Right 'A'
+      error " " letter `shouldBe` Just "a letter"
+
+    it "☯ letterLower" $ do
+      parse "a" letterLower `shouldBe` Right 'a'
+      error "A" letterLower `shouldBe` Just "a lowercase letter"
+
+    it "☯ letterUpper" $ do
+      parse "A" letterUpper `shouldBe` Right 'A'
+      error "a" letterUpper `shouldBe` Just "an uppercase letter"
+
+    it "☯ digit" $ do
+      parse "0" digit `shouldBe` Right '0'
+      error "a" digit `shouldBe` Just "a digit from 0 to 9"
+
+    it "☯ alphanumeric" $ do
+      parse "0" alphanumeric `shouldBe` Right '0'
+      parse "a" alphanumeric `shouldBe` Right 'a'
+      error " " alphanumeric `shouldBe` Just "a letter or digit"
+
+    it "☯ punctuation" $ do
+      parse "." punctuation `shouldBe` Right '.'
+      parse "?" punctuation `shouldBe` Right '?'
+      error " " punctuation `shouldBe` Just "a punctuation character"
+
+    it "☯ char" $ do
+      parse "a" (char 'a') `shouldBe` Right 'a'
+      parse "A" (char 'a') `shouldBe` Right 'A'
+      error " " (char 'a') `shouldBe` Just "the character 'a'"
+
+    it "☯ charCaseSensitive" $ do
+      parse "a" (charCaseSensitive 'a') `shouldBe` Right 'a'
+      error "A" (charCaseSensitive 'a') `shouldBe` Just "the character 'a' (case sensitive)"
+
+    it "☯ except" $ do
+      parse "a" (except space) `shouldBe` Right 'a'
+      error " " (except space) `shouldBe` Just "something else"
+
+  describe "☯ Sequences" $ do
+    it "☯ zeroOrOne" $ do
+      parse "abc!" (zeroOrOne letter) `shouldBe` Right ['a']
+      parse "_bc!" (zeroOrOne letter) `shouldBe` Right []
+
+    it "☯ zeroOrMore" $ do
+      parse "abc!" (zeroOrMore letter) `shouldBe` Right ['a', 'b', 'c']
+      parse "_bc!" (zeroOrMore letter) `shouldBe` Right []
+
+    it "☯ oneOrMore" $ do
+      parse "abc!" (oneOrMore letter) `shouldBe` Right ['a', 'b', 'c']
+      error "_bc!" (oneOrMore letter) `shouldBe` Just "a letter"
+
+    it "☯ chain" $ do
+      parse "_A5" (chain [char '_', letter, digit]) `shouldBe` Right ['_', 'A', '5']

--- a/test/ParserTests.hs
+++ b/test/ParserTests.hs
@@ -5,101 +5,88 @@ import Test.Hspec
 
 parserTests :: SpecWith ()
 parserTests = describe "--== Parser ==--" $ do
-  let error :: String -> Parser a -> Maybe String
-      error source parser = case parse source parser of
-        Left (Expected message _) -> Just message
-        _ -> Nothing
+  let parse' :: String -> Parser a -> Either String a
+      parse' source parser = case parse source parser of
+        Left (Error message _) -> Left message
+        Right x -> Right x
+
+  describe "☯ Control flow" $ do
+    it "☯ succeed" $ do
+      parse' "abc" (succeed True) `shouldBe` Right True
+
+    it "☯ expected" $ do
+      parse' "abc" (expected "something" :: Parser ()) `shouldBe` Left "something"
+
+    it "☯ fmap" $ do
+      parse' "abc" (fmap not (succeed True)) `shouldBe` Right False
+
+    it "☯ orElse" $ do
+      parse' "abc" (succeed True |> orElse (succeed False)) `shouldBe` Right True
+      parse' "abc" (expected "something" |> orElse (succeed False)) `shouldBe` Right False
 
   describe "☯ Single characters" $ do
     it "☯ anyChar" $ do
-      parse "abc" anyChar `shouldBe` Right 'a'
-      parse "" anyChar
-        `shouldBe` Left
-          ( Expected "a character" $
-              State
-                { source = "",
-                  remaining = "",
-                  lastChar = Nothing,
-                  token = Token {name = "", row = 1, col = 1},
-                  stack = []
-                }
-          )
-
-    it "☯ charIf" $ do
-      parse "abc" (charIf ('a' ==) "an 'a'") `shouldBe` Right 'a'
-      parse "xbc" (charIf ('a' ==) "an 'a'")
-        `shouldBe` Left
-          ( Expected "an 'a'" $
-              State
-                { source = "xbc",
-                  remaining = "bc",
-                  lastChar = Just 'x',
-                  token = Token {name = "", row = 1, col = 2},
-                  stack = []
-                }
-          )
+      parse' "abc" anyChar `shouldBe` Right 'a'
+      parse' "" anyChar `shouldBe` Left "a character"
 
     it "☯ space" $ do
-      parse " " space `shouldBe` Right ' '
-      parse "\t" space `shouldBe` Right '\t'
-      parse "\n" space `shouldBe` Right '\n'
-      parse "\r" space `shouldBe` Right '\r'
-      parse "\f" space `shouldBe` Right '\f'
-      parse "\v" space `shouldBe` Right '\v'
-      error "a" space `shouldBe` Just "a blank space"
+      parse' " " space `shouldBe` Right ' '
+      parse' "\t" space `shouldBe` Right '\t'
+      parse' "\n" space `shouldBe` Right '\n'
+      parse' "\r" space `shouldBe` Right '\r'
+      parse' "\f" space `shouldBe` Right '\f'
+      parse' "\v" space `shouldBe` Right '\v'
+      parse' "a" space `shouldBe` Left "a blank space"
 
     it "☯ letter" $ do
-      parse "a" letter `shouldBe` Right 'a'
-      parse "A" letter `shouldBe` Right 'A'
-      error " " letter `shouldBe` Just "a letter"
+      parse' "a" letter `shouldBe` Right 'a'
+      parse' "A" letter `shouldBe` Right 'A'
+      parse' " " letter `shouldBe` Left "a letter"
 
-    it "☯ letterLower" $ do
-      parse "a" letterLower `shouldBe` Right 'a'
-      error "A" letterLower `shouldBe` Just "a lowercase letter"
+    it "☯ lower" $ do
+      parse' "a" lower `shouldBe` Right 'a'
+      parse' "A" lower `shouldBe` Left "a lowercase letter"
 
-    it "☯ letterUpper" $ do
-      parse "A" letterUpper `shouldBe` Right 'A'
-      error "a" letterUpper `shouldBe` Just "an uppercase letter"
+    it "☯ upper" $ do
+      parse' "A" upper `shouldBe` Right 'A'
+      parse' "a" upper `shouldBe` Left "an uppercase letter"
 
     it "☯ digit" $ do
-      parse "0" digit `shouldBe` Right '0'
-      error "a" digit `shouldBe` Just "a digit from 0 to 9"
+      parse' "0" digit `shouldBe` Right '0'
+      parse' "a" digit `shouldBe` Left "a digit from 0 to 9"
 
     it "☯ alphanumeric" $ do
-      parse "0" alphanumeric `shouldBe` Right '0'
-      parse "a" alphanumeric `shouldBe` Right 'a'
-      error " " alphanumeric `shouldBe` Just "a letter or digit"
+      parse' "0" alphanumeric `shouldBe` Right '0'
+      parse' "a" alphanumeric `shouldBe` Right 'a'
+      parse' " " alphanumeric `shouldBe` Left "a letter or digit"
 
     it "☯ punctuation" $ do
-      parse "." punctuation `shouldBe` Right '.'
-      parse "?" punctuation `shouldBe` Right '?'
-      error " " punctuation `shouldBe` Just "a punctuation character"
+      parse' "." punctuation `shouldBe` Right '.'
+      parse' "?" punctuation `shouldBe` Right '?'
+      parse' " " punctuation `shouldBe` Left "a punctuation character"
 
     it "☯ char" $ do
-      parse "a" (char 'a') `shouldBe` Right 'a'
-      parse "A" (char 'a') `shouldBe` Right 'A'
-      error " " (char 'a') `shouldBe` Just "the character 'a'"
+      parse' "a" (char 'a') `shouldBe` Right 'a'
+      parse' "A" (char 'a') `shouldBe` Right 'A'
+      parse' " " (char 'a') `shouldBe` Left "the character 'a'"
 
     it "☯ charCaseSensitive" $ do
-      parse "a" (charCaseSensitive 'a') `shouldBe` Right 'a'
-      error "A" (charCaseSensitive 'a') `shouldBe` Just "the character 'a' (case sensitive)"
-
-    it "☯ except" $ do
-      parse "a" (except space) `shouldBe` Right 'a'
-      error " " (except space) `shouldBe` Just "something else"
+      parse' "a" (charCaseSensitive 'a') `shouldBe` Right 'a'
+      parse' "A" (charCaseSensitive 'a') `shouldBe` Left "the character 'a' (case sensitive)"
 
   describe "☯ Sequences" $ do
     it "☯ zeroOrOne" $ do
-      parse "abc!" (zeroOrOne letter) `shouldBe` Right ['a']
-      parse "_bc!" (zeroOrOne letter) `shouldBe` Right []
+      parse' "abc!" (zeroOrOne letter) `shouldBe` Right ['a']
+      parse' "_bc!" (zeroOrOne letter) `shouldBe` Right []
 
     it "☯ zeroOrMore" $ do
-      parse "abc!" (zeroOrMore letter) `shouldBe` Right ['a', 'b', 'c']
-      parse "_bc!" (zeroOrMore letter) `shouldBe` Right []
+      parse' "abc!" (zeroOrMore letter) `shouldBe` Right ['a', 'b', 'c']
+      parse' "_bc!" (zeroOrMore letter) `shouldBe` Right []
 
     it "☯ oneOrMore" $ do
-      parse "abc!" (oneOrMore letter) `shouldBe` Right ['a', 'b', 'c']
-      error "_bc!" (oneOrMore letter) `shouldBe` Just "a letter"
+      parse' "abc!" (oneOrMore letter) `shouldBe` Right ['a', 'b', 'c']
+      parse' "_bc!" (oneOrMore letter) `shouldBe` Left "a letter"
 
     it "☯ chain" $ do
-      parse "_A5" (chain [char '_', letter, digit]) `shouldBe` Right ['_', 'A', '5']
+      parse' "_A5" (chain [] :: Parser [()]) `shouldBe` Right []
+      parse' "_A5" (chain [char '_', letter, digit]) `shouldBe` Right ['_', 'A', '5']


### PR DESCRIPTION
Convert Parser into a Monad to integrate with `do` notation, as well as adding more common parsers.